### PR TITLE
`pd.Timestamp.months` starts at 1, not at 0 :slightly_smiling_face: 

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Collection of simple baseline models and metrics for standardized evaluation of 
 
 This package computes a variety of baselines and error metrics
 including persistence of both last value and last day of generation,
-comparison to PVLive, and max and zero baselines. 
+comparison to PVLive, and max and zero baselines.
 
 ## Installation
 
@@ -11,13 +11,13 @@ Install with `pip install ocf-ml-metrics`
 
 ## Usage
 
-The easiest way to use this package is to use the 
+The easiest way to use this package is to use the
 convenience function `ocf_ml_metrics.metrics.errors.compute_metrics` that
 computes all the basic error metrics overall, with and without night time,
 for different parts of the year, different times of day, and all forecast
-horizons by default. 
+horizons by default.
 
-There is also `ocf_ml_metrics.evaluation.evaluation.evaluation` that computes metrics after taking in a pandas 
+There is also `ocf_ml_metrics.evaluation.evaluation.evaluation` that computes metrics after taking in a pandas
 dataframe. These metrics are computed for the raw values, normalized values, against simple baseline models,
 and per ID in the input dataframe. The input dataframe required data can be found in the docstring
 

--- a/ocf_ml_metrics/metrics/errors.py
+++ b/ocf_ml_metrics/metrics/errors.py
@@ -73,10 +73,10 @@ def compute_metrics_part_of_year(
     target: np.ndarray,
     datetimes: np.ndarray,
     year_split: dict = {
-        "Winter": (11, 0, 1),
-        "Spring": (2, 3, 4),
-        "Summer": (5, 6, 7),
-        "Fall": (8, 9, 10),
+        "Winter": (12, 1, 2),
+        "Spring": (3, 4, 5),
+        "Summer": (6, 7, 8),
+        "Fall": (9, 10, 11),
     },
     **kwargs,
 ) -> dict:


### PR DESCRIPTION
# Pull Request

## Description

* `pd.Timestamp.months` starts at 1, not at 0 :slightly_smiling_face:. So I've incremented the month numbers for `year_split` in `compute_metrics_part_of_year`
* I've also changed `test_compute_error_part_of_year` so it can detect if `compute_metrics_part_of_year` has correctly split the dates into seasons.
    * Note that this has revealed that `common_metrics` is computing `mae` incorrectly... I'll fix that in another PR!


## How Has This Been Tested?

- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
