### PR TITLE
Added support for calculating common metrics for 2d inputs

### DIFF
--- a/ocf_ml_metrics/metrics/errors.py
+++ b/ocf_ml_metrics/metrics/errors.py
@@ -24,9 +24,16 @@ def common_metrics(predictions: np.ndarray, target: np.ndarray, tag: str = "", *
         Dictionary of error metrics computed over the given data.
     """
     error_dict = {}
+    
+    def _mean(input):
+        # 2+ dimensional input - compute mean but preserve 0th dimension, yields 1-d ndarray
+        if len(predictions.shape) > 1:
+            return np.mean(input, axis=0)
+        else:
+            return np.mean(input)
 
-    error_dict[tag + "mae"] = np.mean(np.abs(predictions - target))
-    error_dict[tag + "rmse"] = np.sqrt(np.mean(np.square(predictions - target)))
+    error_dict[tag + "mae"] = _mean(np.abs(predictions - target))
+    error_dict[tag + "rmse"] = np.sqrt(_mean(np.square(predictions - target)))
 
     return error_dict
 

--- a/ocf_ml_metrics/metrics/errors.py
+++ b/ocf_ml_metrics/metrics/errors.py
@@ -24,7 +24,7 @@ def common_metrics(predictions: np.ndarray, target: np.ndarray, tag: str = "", *
         Dictionary of error metrics computed over the given data.
     """
     error_dict = {}
-    
+
     def _mean(input):
         # 2+ dimensional input - compute mean but preserve 0th dimension, yields 1-d ndarray
         if len(predictions.shape) > 1:

--- a/tests/metrics/test_errors.py
+++ b/tests/metrics/test_errors.py
@@ -17,8 +17,8 @@ def test_common_error_metrics_1d_input():
     for key in ["mae", "rmse"]:
         assert key in errors.keys()
         assert isinstance(errors[key], float)
-        
-        
+
+
 def test_common_error_metrics_2d_input():
     predictions = np.random.random((8, 16))
     target = np.random.random((8, 16))

--- a/tests/metrics/test_errors.py
+++ b/tests/metrics/test_errors.py
@@ -10,13 +10,24 @@ from ocf_ml_metrics.metrics.errors import (
 from tests.consts_for_tests import N_METRICS
 
 
-def test_common_error_metrics():
-    predictions = np.random.random((288, 1))
-    target = np.random.random((288, 1))
+def test_common_error_metrics_1d_input():
+    predictions = np.random.random(8)
+    target = np.random.random(8)
     errors = common_metrics(predictions=predictions, target=target)
     for key in ["mae", "rmse"]:
         assert key in errors.keys()
         assert isinstance(errors[key], float)
+        
+        
+def test_common_error_metrics_2d_input():
+    predictions = np.random.random((8, 16))
+    target = np.random.random((8, 16))
+    errors = common_metrics(predictions=predictions, target=target)
+    for key in ["mae", "rmse"]:
+        assert key in errors.keys()
+        assert isinstance(errors[key], np.ndarray)
+        assert errors[key].shape == (16,)
+        assert errors[key].dtype == np.float64
 
 
 def test_compute_error_part_of_year():


### PR DESCRIPTION
# Pull Request

## Description

During training over batches of data on PVNet, I was receiving errors due to `common_metrics` returning a float for each metric (RMSE & MAE). For multiple forecast horizons (e.g. every 30 minutes), we need `common_metrics` to return a 1-d array, so this PR enables support for checking the input predictions array to `common_metrics` and calculates the mean appropriately depending on the dimensions of the input.

Tests have been updated to include 1-d and 2-d input expectations.

Fixes #

## How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration_

- [x] Yes

_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

- [ ] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
